### PR TITLE
update: add the ability to pin the version

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,8 +20,20 @@ case "$ARCH" in
         ;;
 esac
 
-# Fetch the latest release version from GitHub API
-LATEST_RELEASE=$(curl -s https://api.github.com/repos/holistics/holistics-cli/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+# Check if version is provided via environment variable, otherwise fetch latest
+if [ -n "${HOLISTICS_VERSION:-}" ]; then
+    echo "Using pinned version: $HOLISTICS_VERSION"
+    LATEST_RELEASE="$HOLISTICS_VERSION"
+    # Add 'v' prefix if not present
+    if [[ ! "$LATEST_RELEASE" =~ ^v ]]; then
+        LATEST_RELEASE="v$LATEST_RELEASE"
+    fi
+else
+    echo "Fetching latest release..."
+    # Fetch the latest release version from GitHub API
+    LATEST_RELEASE=$(curl -s https://api.github.com/repos/holistics/holistics-cli/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+fi
+
 
 # Remove 'v' prefix if present
 VERSION=$(echo "$LATEST_RELEASE" | sed 's/^v//')


### PR DESCRIPTION
## Summary
I want to include the ability to pin the holistics version that I want to install. 

The usage will be as follows:
```shell
# Install latest version
curl -fsSL https://raw.githubusercontent.com/holistics/holistics-cli/refs/heads/master/install.sh | bash

# Install specific version
curl -fsSL https://raw.githubusercontent.com/holistics/holistics-cli/refs/heads/master/install.sh | HOLISTICS_VERSION=v1.2.3 bash

# Or export the variable first
export HOLISTICS_VERSION=v1.2.3
curl -fsSL https://raw.githubusercontent.com/holistics/holistics-cli/refs/heads/master/install.sh | bash
```


## Asana
(asana link here)

## Lasting Changes (Technical)

(please list down: code changes/things that have wide-effect; new libraries/functions added that can be used by others; examples below)

* (Added `class EmailValidator` to validate email address' validity)
* (Added `Tenant#is_trial?` check)

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

Please check directly on the box once each of these are done

- [ ] Update CHANGELOG.md
- [ ] Frontend: use new design system (see `yarn docs`)
- [ ] Documentation (if necessary)
- [ ] Tests (integration test/unit test)
- [ ] User Acceptance Test (Product Feature Review)
- [ ] Code Review
