### PR TITLE
feat: support offline mode with env var version pinning and cache fallback

### DIFF
--- a/src/downloader.ts
+++ b/src/downloader.ts
@@ -1,8 +1,8 @@
-import { writeFile, mkdir, stat } from "fs/promises";
+import { writeFile, mkdir, stat, readdir } from "fs/promises";
 import { fetch } from "undici";
 import { extract } from "tar";
 import { join } from "path";
-import { getModulePath, ensureCacheDir } from "./cache";
+import { getCacheDir, getModulePath, ensureCacheDir } from "./cache";
 
 async function downloadAndExtract(pkg: string, version: string) {
   const modulePath = getModulePath(pkg, version);
@@ -24,18 +24,48 @@ async function downloadAndExtract(pkg: string, version: string) {
 }
 
 async function getLatestVersion(pkg: string): Promise<string> {
-  // console.log(`Fetching latest version of ${pkg}...`);
   const res = await fetch(`https://registry.npmjs.org/${pkg}`);
   if (!res.ok) throw new Error(`Failed to fetch package info: ${res.statusText}`);
-  
+
   const data = await res.json();
   const ver = data["dist-tags"]?.latest || "";
-  // console.log(`Latest version is ${ver}`);
   return ver;
 }
 
+async function findCachedVersion(pkg: string): Promise<string | null> {
+  const cacheDir = getCacheDir();
+  const prefix = `${pkg}@`;
+  try {
+    const entries = await readdir(cacheDir);
+    const matches = entries
+      .filter(e => e.startsWith(prefix))
+      .map(e => e.slice(prefix.length))
+      .sort()
+      .reverse();
+    return matches.length > 0 ? matches[0] : null;
+  } catch {
+    return null;
+  }
+}
+
 export async function ensureModule(pkg: string, version?: string) {
-  if (!version) version = await getLatestVersion(pkg);
+  // Allow pinning the version via environment variable to skip npm registry calls entirely
+  if (!version) version = process.env.HOLISTICS_CLI_CORE_VERSION;
+
+  if (!version) {
+    try {
+      version = await getLatestVersion(pkg);
+    } catch (err) {
+      // Offline fallback: if npm is unreachable, try to use a cached version
+      const cached = await findCachedVersion(pkg);
+      if (cached) {
+        console.log(`Network unavailable, using cached version ${pkg}@${cached}`);
+        return getModulePath(pkg, cached);
+      }
+      throw err;
+    }
+  }
+
   const modulePath = getModulePath(pkg, version);
 
   try {


### PR DESCRIPTION
## Summary

Fixes #15 — the CLI binary currently **always contacts `registry.npmjs.org`** to resolve the latest `@holistics/cli-core` version, even when the package is already cached locally. This makes the CLI unusable in network-restricted environments.

This PR adds two mechanisms to `ensureModule` in `src/downloader.ts`:

- **`HOLISTICS_CLI_CORE_VERSION` env var** — when set, the npm registry call is skipped entirely and the specified version is loaded directly from cache
- **Offline fallback** — when the env var is not set and `getLatestVersion()` fails due to a network error, the CLI scans `~/.cache/holistics/` for any previously downloaded version (picking the highest) instead of crashing

## Changes

**`src/downloader.ts`**:
- Added `findCachedVersion()` — scans the cache directory for existing `{pkg}@{version}` entries and returns the highest version found
- Modified `ensureModule()` — checks `HOLISTICS_CLI_CORE_VERSION` env var first, then attempts npm with fallback to cached version on network failure
- Added `readdir` import from `fs/promises` and `getCacheDir` import from `./cache`

## Usage

```bash
# Pin version explicitly (zero network calls)
HOLISTICS_CLI_CORE_VERSION=0.6.13 holistics dbt upload --file-path manifest.json --data-source my_ds

# Or just work offline if cache exists from a previous run
holistics --version  # falls back to cached version when npm is unreachable
```

## Use case: Pre-baked Docker images

```dockerfile
# At build time (network available): download cli-core into cache
RUN holistics --version  # populates ~/.cache/holistics/@holistics/cli-core@x.y.z/

# At runtime (no network): pin the version
ENV HOLISTICS_CLI_CORE_VERSION=0.6.13
RUN holistics dbt upload ...  # works without npm
```

## Test plan

- [ ] Verify `holistics --version` works normally (no env var, network available)
- [ ] Verify `HOLISTICS_CLI_CORE_VERSION=0.6.13 holistics --version` works with pre-populated cache and no network
- [ ] Verify offline fallback: run once to populate cache, then disconnect network and run again without env var
- [ ] Verify error is still thrown when offline with no cache and no env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)